### PR TITLE
Fix test coverage in ci

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__
 .pytest_cache
+bucket.egg-info

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ install:
 - pip install .
 script:
 - flake8 bucket
-- pytest -s tests --cov=bucket --cov-report=term
-- bandit bucket
+- pytest -s tests --cov=$PWD/bucket --cov-report=term
+- bandit -r bucket
 notifications:
   slack: cs-cofc:uCexVCL9fjtSpV4A6YcmrCpj


### PR DESCRIPTION
- Apparently pytest-cov will not report coverage without an making the `tests/` directory a package (using an __init__.py)